### PR TITLE
Protect dashboard with middleware

### DIFF
--- a/my-app/middleware.ts
+++ b/my-app/middleware.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import jwt from 'jsonwebtoken';
+
+const secret = process.env.JWT_SECRET || 'secret';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/dashboard')) {
+    const token = request.cookies.get('token')?.value;
+    if (!token) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+    try {
+      jwt.verify(token, secret);
+    } catch {
+      const url = request.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*'],
+};


### PR DESCRIPTION
## Summary
- add a middleware to validate JWT cookies
- redirect unauthenticated users to `/login`

## Testing
- `npm run lint`
- `npm run build` with `MONGODB_URI` set


------
https://chatgpt.com/codex/tasks/task_e_6856de4412ec8330b46f7002d01e25b8